### PR TITLE
rename github token variable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,7 +11,7 @@ on:
         required: true
       mirror_ssh_private_key:
         required: true
-      github_token:
+      token:
         required: true
 
 jobs:
@@ -54,7 +54,7 @@ jobs:
         env:
           PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.token }}
           script: |
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`


### PR DESCRIPTION
Sometime in the last week or so, Github appears to have made `github_token` a reserved name and broken all our actions that use the shared workflow:

![screenshot-2022-01-04-141849](https://user-images.githubusercontent.com/7821/148072670-ae0011d2-cbe6-4e0e-ae25-f29bfb6de783.png)

The fix appears to be just to rename `github_token` to something else. `token` seems to work.