### PR TITLE
make the apply branch configurable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,6 +6,9 @@ on:
       workingdir:
         required: true
         type: string
+      apply_branch:
+        type: string
+        default: 'master'
     secrets:
       tf_api_token:
         required: true
@@ -81,5 +84,5 @@ jobs:
         if: steps.plan.outcome == 'failure'
         run: exit 1
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        if: github.ref == "refs/heads/${{ inputs.apply_branch }}" && github.event_name == 'push'
         run: terraform apply -auto-approve


### PR DESCRIPTION
The workflow was originally written to run a `terraform plan` on `pull_request` actions and `terraform apply` on a `push` to the `master` branch.

Not all of our TF repos use `master` as their default branch though. Newer ones are going to be `main` and Wharf still mostly operates on `develop`.

This adds an `apply_branch` input to the workflow to allow this to be set. It defaults to `master` so it will be backwards compatible with existing repos that use it.
