### PR TITLE
bump actions/checkout to v3

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ${{ inputs.workingdir }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:


### PR DESCRIPTION
address a warning that GH is showing us on actions runs:

![screenshot-2022-10-17-152005](https://user-images.githubusercontent.com/7821/196201844-88641aff-f39c-4013-b31e-15572325c843.png)
