### PR TITLE
bump hashicorp/setup-terraform action to v2

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           cli_config_credentials_token: ${{ secrets.tf_api_token }}
           terraform_version: ${{ inputs.tf_version }}


### PR DESCRIPTION
clear the other warning about old node versions
