### PR TITLE
add terraform drift detection workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 * @thraxil
 
 .github/workflows/terraform.yml @appsembler/terraform
+.github/workflows/tfdrift.yml @appsembler/terraform

--- a/.github/workflows/tfdrift.yml
+++ b/.github/workflows/tfdrift.yml
@@ -1,0 +1,38 @@
+name: 'Terraform Drift Detection Workflow'
+
+on:
+  workflow_call:
+    inputs:
+      workingdir:
+        required: true
+        type: string
+      tf_version:
+        type: string
+        default: '1.0.0'
+    secrets:
+      tf_api_token:
+        required: true
+      token:
+        required: true
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.workingdir }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          cli_config_credentials_token: ${{ secrets.tf_api_token }}
+          terraform_version: ${{ inputs.tf_version }}
+      - name: Terraform Init
+        id: init
+        run: terraform init
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -detailed-exitcode


### PR DESCRIPTION
There are a few TF projects that I'd like to have automated drift detection running on. With this workflow, we can add a github action to run it daily and then github actions will send us an alert any time `terraform plan` shows any changes to be made (ie, our TF code is out of sync with what's running).
